### PR TITLE
Fix mixed Org loading

### DIFF
--- a/config/init.el
+++ b/config/init.el
@@ -10,8 +10,8 @@
 ;;   (straight-vc-git-default-protocol 'git)
 ;;   (straight-vc-git-force-protocol t))
 
-(use-package org
-  :straight org-plus-contrib)
+(use-package org :straight org-plus-contrib)
+(use-package ob-tangle :straight org-plus-contrib)
 
 (defun init-load()
   (interactive)


### PR DESCRIPTION
declare ob-tangle as org-plus-contrib before using it.
This should prevent loading mixed versions of Org and hopefully:

https://github.com/raxod502/straight.el/issues/624